### PR TITLE
config-gen: generate options.json with correct keys

### DIFF
--- a/dcos_hdfs/cli.py
+++ b/dcos_hdfs/cli.py
@@ -36,8 +36,8 @@ def gen_config(args):
     with open (filename, "r") as config_file:
         data = config_file.read().encode('ascii')
 
-    config = {}
-    config[constants.custom_config_key] = base64.b64encode(data).decode('utf-8')
+    config = {constants.root_key: {}}
+    config[constants.root_key][constants.custom_config_key] = base64.b64encode(data).decode('utf-8')
 
     with open('options.json', 'w') as config_output:
         json.dump(config, config_output,

--- a/dcos_hdfs/constants.py
+++ b/dcos_hdfs/constants.py
@@ -1,4 +1,5 @@
 version = '0.1.0'
-"""DCOS Spark version"""
+"""DCOS HDFS version"""
 
-custom_config_key = 'hdfs/custom-config'
+root_key = 'hdfs'
+custom_config_key = 'custom-config'


### PR DESCRIPTION
The HDFS package in the Mesosphere Universe repository currently expects to find the custom configuration at `hdfs.custom-config` (not `hdfs/custom-config`). Without this change, the generated config never takes effect when you run:

`dcos package install --options=./options.json`